### PR TITLE
Long support

### DIFF
--- a/ts3/protocol.py
+++ b/ts3/protocol.py
@@ -26,6 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import sys
 import telnetlib
 from threading import Lock
 
@@ -239,8 +240,12 @@ class TS3Proto():
         @type value: string/int/long
 
         """
+        if sys.version_info < (3,):
+            integer_types = (int, long, )
+        else:
+            integer_types = (int, )
 
-        if type(value) in (int, long, ):
+        if isinstance(value, integer_types):
             return str(value)
 
         for i, j in ts3_escape:

--- a/ts3/protocol.py
+++ b/ts3/protocol.py
@@ -240,7 +240,7 @@ class TS3Proto():
 
         """
 
-        if isinstance(value, int):
+        if type(value) in (int, long, ):
             return str(value)
 
         for i, j in ts3_escape:

--- a/ts3/protocol.py
+++ b/ts3/protocol.py
@@ -236,7 +236,7 @@ class TS3Proto():
         Escape a value into a TS3 compatible string
 
         @param value: Value
-        @type value: string/int
+        @type value: string/int/long
 
         """
 


### PR DESCRIPTION
Long and Int should both be convert into strings when constructing commands. 

In addition -- Django's positive integer fields returns the type of long. Small helper for cleaner code. 
